### PR TITLE
build execute-webhook

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -33,7 +33,10 @@ jobs:
         env:
           CI: true
           NODE_OPTIONS: --max-old-space-size=4096
-
+      - name: '[Execute-Webhook] Build'
+        run: yarn exec-wk build
+        env:
+          CI: true
       - name: '[API] Build'
         run: yarn api build:test
         env:


### PR DESCRIPTION
execute-webhook repository is not building on Github Actions and this is giving errors to build API